### PR TITLE
bring support for subkeys (using .)

### DIFF
--- a/dist/Logger.js
+++ b/dist/Logger.js
@@ -1,4 +1,3 @@
-import getConfig from "./config.js";
 const ESC = "\u001b";
 const RESET = ESC + "[m";
 const GRAY = ESC + "[37m";
@@ -18,7 +17,7 @@ export default class Logger {
     constructor(actor, color) {
         this.actor = actor;
         this.color = color;
-        if (!getConfig("debug", false)) {
+        if (!global.debug) {
             this.debug = () => { }; // only enable debug logs when debugging is on
         }
     }

--- a/dist/config.d.ts
+++ b/dist/config.d.ts
@@ -1,4 +1,4 @@
 export declare const config: any;
 type ConfigValue = string | number | boolean;
-export default function getConfig(key: string, defaultValue?: ConfigValue): any;
+export default function getConfig<T extends ConfigValue>(key: string, defaultValue?: T): T;
 export {};

--- a/dist/config.d.ts
+++ b/dist/config.d.ts
@@ -1,2 +1,4 @@
 export declare const config: any;
-export default function getConfig(key: string, defaultValue?: any): any;
+type ConfigValue = string | number | boolean;
+export default function getConfig(key: string, defaultValue?: ConfigValue): any;
+export {};

--- a/dist/config.js
+++ b/dist/config.js
@@ -14,7 +14,7 @@ export default function getConfig(key, defaultValue) {
         error = e;
     }
     value = value ?? process.env[key] ?? process.env[key.replaceAll(".", "_")] ?? defaultValue;
-    console.log("config:", key, value);
+    //console.log("config:", key, value)
     if (value != undefined) {
         if (error)
             logger.warn(error);
@@ -22,10 +22,6 @@ export default function getConfig(key, defaultValue) {
     }
     throw new Error(error) || new Error("Config key " + key + " not found");
 }
-console.log("test:", getConfig("test", "?"));
-console.log("this.is.a.path:", getConfig("this.is.a.path", "?"));
-console.log("smtp.port", getConfig("smtp.port", "?"));
-console.log("smtp_port", getConfig("smtp_port", "?"));
 function searchJsonKey(key, defaultValue) {
     const path = key.split(".");
     //console.log("[getConfig]", key, path)

--- a/dist/config.js
+++ b/dist/config.js
@@ -13,7 +13,7 @@ export default function getConfig(key, defaultValue) {
     catch (e) {
         error = e;
     }
-    value = value ?? process.env[key] ?? process.env[key.replaceAll(".", "_")] ?? defaultValue;
+    value = value ?? getEnvVar(key) ?? defaultValue;
     //console.log("config:", key, value)
     if (value != undefined) {
         if (error)
@@ -24,6 +24,24 @@ export default function getConfig(key, defaultValue) {
         return value;
     }
     throw new Error(error) || new Error("Config key " + key + " not found");
+}
+function getEnvVar(key) {
+    const value = process.env[key] ?? process.env[key.replaceAll(".", "_")];
+    if (!value)
+        return;
+    return parseStringValue(value);
+}
+function parseStringValue(value) {
+    // boolean
+    if (value == "true")
+        return true;
+    else if (value == "false")
+        return false;
+    // number
+    else if (!isNaN(Number(value)))
+        return Number(value);
+    // string
+    return value;
 }
 function searchJsonKey(key, defaultValue) {
     const path = key.split(".");

--- a/dist/config.js
+++ b/dist/config.js
@@ -1,12 +1,51 @@
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
+import Logger from "./Logger.js";
 export const config = existsSync("config.json") ? JSON.parse(await readFile("config.json", "utf-8")) : {};
+const logger = new Logger("config", "PINK");
 export default function getConfig(key, defaultValue) {
-    if (config[key])
-        return config[key];
-    if (process.env[key])
-        return process.env[key];
-    if (defaultValue != undefined)
-        return defaultValue;
-    throw new Error("Config key " + key + " not found"); // TODO: better error handling?
+    let value = undefined;
+    let error = undefined;
+    try {
+        value = searchJsonKey(key);
+        //console.log(`json: [${searchJsonKey(key)}]`)
+    }
+    catch (e) {
+        error = e;
+    }
+    value = value ?? process.env[key] ?? process.env[key.replaceAll(".", "_")] ?? defaultValue;
+    console.log("config:", key, value);
+    if (value != undefined) {
+        if (error)
+            logger.warn(error);
+        return value;
+    }
+    throw new Error(error) || new Error("Config key " + key + " not found");
+}
+console.log("test:", getConfig("test", "?"));
+console.log("this.is.a.path:", getConfig("this.is.a.path", "?"));
+console.log("smtp.port", getConfig("smtp.port", "?"));
+console.log("smtp_port", getConfig("smtp_port", "?"));
+function searchJsonKey(key, defaultValue) {
+    const path = key.split(".");
+    //console.log("[getConfig]", key, path)
+    let value = config[path[0]];
+    if (!value) {
+        if (path.length > 1)
+            throw `Config key ${key} not found (${path[0]} is invalid: ${value})`;
+        return;
+    }
+    for (let i = 1; i < path.length; i++) {
+        if (typeof value != "object")
+            throw `Config key ${key} not found (${path.slice(0, i).join(".")} is ${typeof value})`;
+        value = value[path[i]];
+    }
+    if (isValid(value))
+        return value;
+    if (typeof value == "object")
+        logger.warn(`Invalid config value (${key}):`, value instanceof Array ? "[...]" : "{...}");
+    return;
+}
+function isValid(value) {
+    return ["string", "number", "boolean"].includes(typeof value);
 }

--- a/dist/config.js
+++ b/dist/config.js
@@ -18,6 +18,9 @@ export default function getConfig(key, defaultValue) {
     if (value != undefined) {
         if (error)
             logger.warn(error);
+        if (defaultValue != undefined && typeof value != typeof defaultValue) {
+            throw new Error(`Config type of ${key} does not match default value (${typeof defaultValue}).`);
+        }
         return value;
     }
     throw new Error(error) || new Error("Config key " + key + " not found");

--- a/dist/main.js
+++ b/dist/main.js
@@ -5,6 +5,7 @@ import User from "./models/User.js";
 import Mail from "./models/Mail.js";
 import getConfig from "./config.js";
 import { readFile } from "node:fs/promises";
+global.debug = getConfig("debug", false);
 export const sql = new Sequelize({
     database: getConfig("db_database"),
     dialect: getConfig("db_dialect"),

--- a/dist/main.js
+++ b/dist/main.js
@@ -28,4 +28,12 @@ secure: if (getConfig("pop3s.enabled", false) || getConfig("smtps.enabled", fals
     catch (ignore) {
         break secure;
     }
-
+    if (getConfig("pop3s.enabled", false))
+        new POP3Server(getConfig("pop3s.port", 995), true, tlsKey, tlsCert); // Port 110 for regular POP3, 995 for POP3S
+    if (getConfig("smtps.enabled", false))
+        new SMTPServer(getConfig("smtps.port", 465), true, tlsKey, tlsCert); // Port 25 for regular SMTP, 465 for SMTPS
+}
+if (getConfig("smtp.enabled", true))
+    new SMTPServer(getConfig("smtp.port", 25), false); // Port 25 for regular SMTP, 465 for SMTPS
+if (getConfig("pop3.enabled", true))
+    new POP3Server(getConfig("pop3.port", 110), false); // Port 110 for regular POP3, 995 for POP3S

--- a/dist/main.js
+++ b/dist/main.js
@@ -7,10 +7,10 @@ import getConfig from "./config.js";
 import { readFile } from "node:fs/promises";
 global.debug = getConfig("debug", false);
 export const sql = new Sequelize({
-    database: getConfig("db_database"),
-    dialect: getConfig("db_dialect"),
-    username: getConfig("db_username"),
-    password: getConfig("db_password"),
+    database: getConfig("db.database"),
+    dialect: getConfig("db.dialect"),
+    username: getConfig("db.username"),
+    password: getConfig("db.password"),
     models: [User, Mail]
 });
 // await sql.sync({ alter: true })

--- a/dist/main.js
+++ b/dist/main.js
@@ -19,19 +19,19 @@ export const sql = new Sequelize({
 // 	username: "cfp",
 // 	password: "1234"
 // })
-secure: if (getConfig("enable_pop3s", false) || getConfig("enable_smtps", false)) {
+secure: if (getConfig("pop3s.enabled", false) || getConfig("smtps.enabled", false)) {
     let tlsKey, tlsCert;
     try {
-        tlsKey = await readFile(getConfig("tls_key", "cert/privkey.pem"));
-        tlsCert = await readFile(getConfig("tls_cert", "cert/fullchain.pem"));
+        tlsKey = await readFile(getConfig("tls.key", "cert/privkey.pem"));
+        tlsCert = await readFile(getConfig("tls.cert", "cert/fullchain.pem"));
     }
     catch (ignore) {
         break secure;
     }
-    if (getConfig("enable_pop3s", false))
-        new POP3Server(getConfig("pop3s_port", 995), true, tlsKey, tlsCert); // Port 110 for regular POP3, 995 for POP3S
+    if (getConfig("pop3s.enabled", false))
+        new POP3Server(getConfig("pop3s.port", 995), true, tlsKey, tlsCert); // Port 110 for regular POP3, 995 for POP3S
 }
-if (getConfig("enable_smtp", true))
-    new SMTPServer(getConfig("smtp_port", 25)); // Port 25 for regular SMTP, 465 for SMTPS
-if (getConfig("enable_pop3", true))
-    new POP3Server(getConfig("pop3_port", 110), false); // Port 110 for regular POP3, 995 for POP3S
+if (getConfig("smtp.enabled", true))
+    new SMTPServer(getConfig("smtp.port", 25)); // Port 25 for regular SMTP, 465 for SMTPS
+if (getConfig("pop3.enabled", true))
+    new POP3Server(getConfig("pop3.port", 110), false); // Port 110 for regular POP3, 995 for POP3S

--- a/dist/smtp/SMTP.js
+++ b/dist/smtp/SMTP.js
@@ -27,7 +27,7 @@ export default class SMTP {
         const recipients = info.to.filter(email => email.endsWith("@" + serverName));
         for (const rec of recipients) {
             logger.log("Forwarding mail to " + rec);
-            const user = await User.findOne({ where: { username: rec.split("@")[0] } });
+            const user = await User.findOne({ where: { username: rec.substring(0, rec.lastIndexOf("@")) } });
             if (!user) {
                 logger.error("User " + rec + " does not exist.");
                 // Since we verify the recipients at the RCPT TO command, we should never get here, but you never know

--- a/dist/smtp/SMTPServer.js
+++ b/dist/smtp/SMTPServer.js
@@ -18,7 +18,7 @@ export default class SMTPServer {
     connection(sock) {
         const status = sendStatus(sock);
         logger.log("Client connected");
-        status(220, { message: getConfig("smtp_header", "SMTP Server ready") });
+        status(220, { message: getConfig("smtp.header", "SMTP Server ready") });
         let receivingData = false;
         let info = {
             from: "",

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,5 +1,3 @@
-import getConfig from "./config.js"
-
 const ESC = "\u001b"
 const RESET = ESC + "[m"
 const GRAY  = ESC + "[37m"
@@ -18,7 +16,7 @@ const COLOR = {
 export default class Logger {
 
 	constructor(private readonly actor: string, private readonly color: keyof typeof COLOR) {
-		if (!getConfig("debug", false)) {
+		if (!global.debug) {
 			this.debug = () => {} // only enable debug logs when debugging is on
 		}
 	}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,59 @@
 import { existsSync } from "fs"
 import { readFile } from "fs/promises"
+import Logger from "./Logger.js"
 
 export const config = existsSync("config.json") ? JSON.parse(await readFile("config.json", "utf-8")) : {}
 
-export default function getConfig(key: string, defaultValue?: any) {
-	if(config[key]) return config[key]
-	if(process.env[key]) return process.env[key]
-	if(defaultValue != undefined) return defaultValue
-	throw new Error("Config key " + key + " not found") // TODO: better error handling?
+const logger = new Logger("config", "PINK")
+
+type ConfigValue = string | number | boolean
+
+export default function getConfig(key: string, defaultValue?: ConfigValue): any {
+	let value: ConfigValue | undefined = undefined
+	let error: string | undefined = undefined
+	try {
+		value = searchJsonKey(key)
+		//console.log(`json: [${searchJsonKey(key)}]`)
+	} catch (e: any) {
+		error = e
+	}
+	
+	value = value ?? process.env[key] ?? process.env[key.replaceAll(".", "_")] ?? defaultValue
+	console.log("config:", key, value)
+	if (value != undefined) {
+		if (error) logger.warn(error)
+		return value
+	}
+
+	throw new Error(error) || new Error("Config key " + key + " not found")
+}
+
+console.log("test:", getConfig("test", "?"))
+console.log("this.is.a.path:", getConfig("this.is.a.path", "?"))
+console.log("smtp.port", getConfig("smtp.port", "?"))
+console.log("smtp_port", getConfig("smtp_port", "?"))
+
+function searchJsonKey(key: string, defaultValue?: ConfigValue): ConfigValue | undefined {
+	const path = key.split(".")
+	//console.log("[getConfig]", key, path)
+
+	let value: any = config[path[0]]
+	if (!value) {
+		if (path.length > 1) throw `Config key ${key} not found (${path[0]} is invalid: ${value})`
+		return
+	}
+
+	for (let i = 1; i < path.length; i++) {
+		if (typeof value != "object") throw `Config key ${key} not found (${path.slice(0, i).join(".")} is ${typeof value})`
+		value = value[path[i]]
+	}
+
+	if (isValid(value)) return value
+	if (typeof value == "object") logger.warn(`Invalid config value (${key}):`, value instanceof Array ? "[...]" : "{...}")
+
+	return
+}
+
+function isValid(value: any): value is ConfigValue {
+	return ["string", "number", "boolean"].includes(typeof value)
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export default function getConfig(key: string, defaultValue?: ConfigValue): any 
 	}
 	
 	value = value ?? process.env[key] ?? process.env[key.replaceAll(".", "_")] ?? defaultValue
-	console.log("config:", key, value)
+	//console.log("config:", key, value)
 	if (value != undefined) {
 		if (error) logger.warn(error)
 		return value
@@ -27,11 +27,6 @@ export default function getConfig(key: string, defaultValue?: ConfigValue): any 
 
 	throw new Error(error) || new Error("Config key " + key + " not found")
 }
-
-console.log("test:", getConfig("test", "?"))
-console.log("this.is.a.path:", getConfig("this.is.a.path", "?"))
-console.log("smtp.port", getConfig("smtp.port", "?"))
-console.log("smtp_port", getConfig("smtp_port", "?"))
 
 function searchJsonKey(key: string, defaultValue?: ConfigValue): ConfigValue | undefined {
 	const path = key.split(".")

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ export default function getConfig<T extends ConfigValue>(key: string, defaultVal
 		error = e
 	}
 	
-	value = value ?? process.env[key] ?? process.env[key.replaceAll(".", "_")] ?? defaultValue
+	value = value ?? getEnvVar(key) ?? defaultValue
 	//console.log("config:", key, value)
 	if (value != undefined) {
 		if (error) logger.warn(error)
@@ -29,6 +29,23 @@ export default function getConfig<T extends ConfigValue>(key: string, defaultVal
 	}
 
 	throw new Error(error) || new Error("Config key " + key + " not found")
+}
+
+function getEnvVar(key: string): ConfigValue | undefined {
+	const value = process.env[key] ?? process.env[key.replaceAll(".", "_")]
+	if (!value) return
+
+	return parseStringValue(value)
+}
+
+function parseStringValue(value: string): ConfigValue {
+	// boolean
+	if (value == "true") return true
+	else if (value == "false") return false
+	// number
+	else if (!isNaN(Number(value))) return Number(value)
+	// string
+	return value
 }
 
 function searchJsonKey(key: string, defaultValue?: ConfigValue): ConfigValue | undefined {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ const logger = new Logger("config", "PINK")
 
 type ConfigValue = string | number | boolean
 
-export default function getConfig(key: string, defaultValue?: ConfigValue): any {
+export default function getConfig<T extends ConfigValue>(key: string, defaultValue?: T): T {
 	let value: ConfigValue | undefined = undefined
 	let error: string | undefined = undefined
 	try {
@@ -22,7 +22,10 @@ export default function getConfig(key: string, defaultValue?: ConfigValue): any 
 	//console.log("config:", key, value)
 	if (value != undefined) {
 		if (error) logger.warn(error)
-		return value
+		if (defaultValue != undefined && typeof value != typeof defaultValue) {
+			throw new Error(`Config type of ${key} does not match default value (${typeof defaultValue}).`)
+		}
+		return value as T
 	}
 
 	throw new Error(error) || new Error("Config key " + key + " not found")

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,8 @@ import getConfig from "./config.js";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 
+global.debug = getConfig("debug", false)
+
 export const sql = new Sequelize({
   database: getConfig("db_database"),
   dialect: getConfig("db_dialect"),

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,17 +25,17 @@ export const sql = new Sequelize({
 // 	password: "1234"
 // })
 
-secure: if (getConfig("enable_pop3s", false) || getConfig("enable_smtps", false)) {
+secure: if (getConfig("pop3s.enabled", false) || getConfig("smtps.enabled", false)) {
 	let tlsKey: Buffer, tlsCert: Buffer
 	try {
-		tlsKey  = await readFile(getConfig("tls_key",  "cert/privkey.pem"))
-		tlsCert = await readFile(getConfig("tls_cert", "cert/fullchain.pem"))
+		tlsKey  = await readFile(getConfig("tls.key",  "cert/privkey.pem"))
+		tlsCert = await readFile(getConfig("tls.cert", "cert/fullchain.pem"))
 	} catch (ignore) {
 		break secure
 	}
 
-	if (getConfig("enable_pop3s", false)) new POP3Server(getConfig("pop3s_port", 995), true, tlsKey, tlsCert) // Port 110 for regular POP3, 995 for POP3S
+	if (getConfig("pop3s.enabled", false)) new POP3Server(getConfig("pop3s.port", 995), true, tlsKey, tlsCert) // Port 110 for regular POP3, 995 for POP3S
 }
 
-if (getConfig("enable_smtp", true)) new SMTPServer(getConfig("smtp_port", 25)) // Port 25 for regular SMTP, 465 for SMTPS
-if (getConfig("enable_pop3", true)) new POP3Server(getConfig("pop3_port", 110), false) // Port 110 for regular POP3, 995 for POP3S
+if (getConfig("smtp.enabled", true)) new SMTPServer(getConfig("smtp.port", 25)) // Port 25 for regular SMTP, 465 for SMTPS
+if (getConfig("pop3.enabled", true)) new POP3Server(getConfig("pop3.port", 110), false) // Port 110 for regular POP3, 995 for POP3S

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,16 +4,16 @@ import { Sequelize } from 'sequelize-typescript';
 import User from "./models/User.js";
 import Mail from "./models/Mail.js";
 import getConfig from "./config.js";
-import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { Dialect } from "sequelize"
 
-global.debug = getConfig("debug", false)
+global.debug = getConfig("debug", false) as any
 
 export const sql = new Sequelize({
-  database: getConfig("db_database"),
-  dialect: getConfig("db_dialect"),
-  username: getConfig("db_username"),
-  password: getConfig("db_password"),
+  database: getConfig<string>("db.database"),
+  dialect: getConfig<Dialect>("db.dialect"),
+  username: getConfig<string>("db.username"),
+  password: getConfig<string>("db.password"),
   models: [User, Mail]
 });
 

--- a/src/smtp/SMTPServer.ts
+++ b/src/smtp/SMTPServer.ts
@@ -25,7 +25,7 @@ export default class SMTPServer {
 		const status = sendStatus(sock)
 
 		logger.log("Client connected")
-		status(220, { message: getConfig("smtp_header", "SMTP Server ready") })
+		status(220, { message: getConfig("smtp.header", "SMTP Server ready") })
 		let receivingData = false
 		let info = {
 			from: "",


### PR DESCRIPTION
Adds support for dotted config keys.

Example: `smtp.port`
In config.json, this will correspond to:
```json
{
  "smtp": {
    "port": 21
  }
}
```
In the environment, both `smtp.port` and `smtp_port` will be accepted.