### PR TITLE
Switch to Argon2id

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/main.js",
   "scripts": {
     "stylefix": "npx eslint ./src/ --fix",
-	"style": "npx eslint ./src/",
-	"build": "npm run stylefix & tsc",
+    "style": "npx eslint ./src/",
+    "build": "npm run stylefix & tsc",
     "test": "node ./dist/test/main.js"
   },
   "repository": {
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/creelonestudios/mailverse#readme",
   "type": "module",
   "dependencies": {
+    "argon2": "^0.31.2",
     "mariadb": "^3.1.2",
     "mysql2": "^3.3.0",
     "sequelize": "^6.31.1",


### PR DESCRIPTION
Argon2 uses a more computationally expensive hashing algorithm that is harder to crack.<br>
Also, it uses salts automatically and includes them in the output hash. Neat.

See
- [CodeQL Warning](https://github.com/creelonestudios/mailverse/security/code-scanning/444)
- [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)
- [NPM Argon2](https://www.npmjs.com/package/argon2)

I could not find where password hashes are created, but here is code for that:
```ts
import * as argon2 from "argon2"
// ...
const password = // ...
try {
	const hash = await argon2.hash(password)
} catch (err) {
	// ...
}
```