### PR TITLE
CodeQL #404: no-explicit-any (typescript-eslint/no-explicit-any)

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,3 +1,7 @@
+import getConfig from "./config.js"
+
+const debug = getConfig<boolean>("debug", false)
+
 const ESC = "\u001b"
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -17,7 +21,7 @@ const COLOR = { GRAY, DARK, RED, GREEN, YELLOW, PINK, TEAL, WHITE }
 export default class Logger {
 
 	constructor(private readonly actor: string, private readonly color: keyof typeof COLOR) {
-		if (!global.debug) this.debug = () => {} // only enable debug logs when debugging is on
+		if (debug) this.debug = () => {} // only enable debug logs when debugging is on
 	}
 
 	log(...message: string[]) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,6 @@ import User from "./models/User.js"
 import getConfig from "./config.js"
 import { readFile } from "node:fs/promises"
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-global.debug = getConfig("debug", false) as any
-
 export const sql = new Sequelize({
 	database: getConfig<string>("db.database"),
 	dialect:  getConfig<Dialect>("db.dialect"),


### PR DESCRIPTION
See [CodeQL #404](https://github.com/creelonestudios/mailverse/security/code-scanning/404)

Some refactoring